### PR TITLE
MySQL supports boolean type

### DIFF
--- a/Glorp.package/GlorpMySQLBooleanType.class/README.md
+++ b/Glorp.package/GlorpMySQLBooleanType.class/README.md
@@ -1,0 +1,1 @@
+Boolean type for MySQL platform. MySQL stores boolean as tinyint(1)

--- a/Glorp.package/GlorpMySQLBooleanType.class/instance/converterForStType..st
+++ b/Glorp.package/GlorpMySQLBooleanType.class/instance/converterForStType..st
@@ -1,0 +1,4 @@
+converting
+converterForStType: aClass
+	(aClass includesBehavior: Boolean) ifTrue: [^self platform converterNamed: #booleanToInteger].
+	^self platform nullConverter.

--- a/Glorp.package/GlorpMySQLBooleanType.class/properties.json
+++ b/Glorp.package/GlorpMySQLBooleanType.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "LaurentLaffont 4/25/2018 14:33",
+	"super" : "GlorpBooleanType",
+	"category" : "Glorp-Types",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "GlorpMySQLBooleanType",
+	"type" : "normal"
+}

--- a/Glorp.package/MySQLPlatform.class/instance/boolean.st
+++ b/Glorp.package/MySQLPlatform.class/instance/boolean.st
@@ -1,0 +1,3 @@
+types
+boolean
+	^self typeNamed: #boolean ifAbsentPut: [GlorpBooleanType new typeString: 'boolean'].

--- a/Glorp.package/MySQLPlatform.class/instance/boolean.st
+++ b/Glorp.package/MySQLPlatform.class/instance/boolean.st
@@ -1,3 +1,3 @@
 types
 boolean
-	^self typeNamed: #boolean ifAbsentPut: [GlorpBooleanType new typeString: 'boolean'].
+	^self typeNamed: #boolean ifAbsentPut: [GlorpMySQLBooleanType new typeString: 'boolean'].


### PR DESCRIPTION
Without this, direct mapping does not work for MySQL boolean fields (before GLORP MySQLPlatform was generating a smallint(6) for boolean)