### PR TITLE
udbcsqlite3boolean

### DIFF
--- a/Glorp.package/UDBCSQLite3Platform.class/instance/boolean.st
+++ b/Glorp.package/UDBCSQLite3Platform.class/instance/boolean.st
@@ -1,0 +1,5 @@
+types
+boolean
+	"Booleans are represented as integers within the database, but converted to Booleans by the driver"
+
+	^self typeNamed: #boolean ifAbsentPut: [GlorpBooleanType new typeString: 'boolean'].


### PR DESCRIPTION
UDBC SQLite3 driver now converts booleans from integer to BooleanThis follows on from commit 1ab24d4 which modifies the UDBC driver to return a Boolean instead of an integer.