### PR TITLE
Fix test for GlorpOneToOneDBTest shorCircuiting proxies that return nil

### DIFF
--- a/Glorp/RelationshipMapping.class.st
+++ b/Glorp/RelationshipMapping.class.st
@@ -448,9 +448,9 @@ RelationshipMapping >> mapObject: anObject inElementBuilder: anElementBuilder [
 				glorpOwner: anObject;
 				glorpArmProxy.
 			"If we know in advance the proxy would return nil, or an empty collection, just put that in rather than the proxy"
-			"(proxy query shortCircuitEmptyReturn: parameters)
+			(proxy query shortCircuitEmptyReturn: parameters)
 				ifTrue: [proxy getValue]
-				ifFalse: [proxy]"]
+				ifFalse: [proxy]]
 		ifFalse:
 			[(self queryFor: anElementBuilder)
 				executeWithParameters: parameters


### PR DESCRIPTION
Puts back code that was commented out for short circuit evaluating proxies that can be determined to evaluate to nil.