### PR TITLE
Add a test case for login using the session

### DIFF
--- a/Glorp-Integration-Tests/GlorpDatabaseSessionTest.class.st
+++ b/Glorp-Integration-Tests/GlorpDatabaseSessionTest.class.st
@@ -28,6 +28,15 @@ GlorpDatabaseSessionTest >> tearDown [
 ]
 
 { #category : #tests }
+GlorpDatabaseSessionTest >> testLoginIfError [
+
+	[ 
+	session loginIfError: [ :error | self fail ].
+	self assert: session isLoggedIn ]
+		ensure: [ session logout ]
+]
+
+{ #category : #tests }
 GlorpDatabaseSessionTest >> testWriteRow [
 	| rowToWrite fields rowReadFromDatabase |
 	rowToWrite := session system examplePersonRow2.


### PR DESCRIPTION
Some DatabaseDrivers don't implement all the methods required to login using the session. This test case expose this error.