### PR TITLE
Add a test case for delete:where:

### DIFF
--- a/Glorp-Integration-Tests/GlorpDeleteTest.class.st
+++ b/Glorp-Integration-Tests/GlorpDeleteTest.class.st
@@ -413,6 +413,16 @@ GlorpDeleteTest >> testDeleteWhenRemovingFromAnExclusiveCollection [
 ]
 
 { #category : #tests }
+GlorpDeleteTest >> testDeleteWhere [
+
+	[ self setUpCustomer.
+	session inUnitOfWorkDo: [ session delete: GlorpCustomer where: [ :each | each id = 1 ] ].
+	self checkCustomerDeletedInDatabase
+	]
+		ensure: [ session rollbackTransaction ]
+]
+
+{ #category : #tests }
 GlorpDeleteTest >> testNormalDeleteOnFolders [
 	| user |
 	


### PR DESCRIPTION
Add a new test case for `delete:where`. This case reproduces a bug in the SQLite3 driver.