### PR TITLE
Fixes queries for SQLite dates not working.

### DIFF
--- a/Glorp-Integration-Tests/GlorpObjectMappedToImaginaryTableTest.class.st
+++ b/Glorp-Integration-Tests/GlorpObjectMappedToImaginaryTableTest.class.st
@@ -159,6 +159,17 @@ GlorpObjectMappedToImaginaryTableTest >> testReadWithDateArithmeticInWhereClause
 ]
 
 { #category : #tests }
+GlorpObjectMappedToImaginaryTableTest >> testReadWithDateFieldInWhereClause [
+
+	| rentals |
+	rentals := session read: GlorpVideoRental where: [ :each | 
+		           each dueDate in: { 
+				           Date today.
+				           Date yesterday } ].
+	self deny: rentals isEmpty
+]
+
+{ #category : #tests }
 GlorpObjectMappedToImaginaryTableTest >> testRefreshItemWithMappedPrimaryKeys [
 	"Prior to vw8.0, Glorp would DNU if trying to refresh an object whose table's primaryKeys were values mapped to other objects, not directly to its instVars.  The primaryKeys of VIDEO_CREDIT_STATUS are mapped to objects in the instVars of its class GlorpVideoCreditStatus.  The refresh: now uses a base that knows its object's descriptor so no longer DNUs in this test."
 

--- a/Glorp/UDBCSQLite3Platform.class.st
+++ b/Glorp/UDBCSQLite3Platform.class.st
@@ -30,17 +30,6 @@ UDBCSQLite3Platform >> isUDBCSQLite3Platform [
 ]
 
 { #category : #'conversion-times' }
-UDBCSQLite3Platform >> printDate: aDateString for: aType [
-
-	aDateString isNil ifTrue: [^'NULL'].
-	^ String streamContents: [ :str |
-		str nextPut: $".
-		aDateString printOn: str.
-		str nextPut: $" ]
-
-]
-
-{ #category : #'conversion-times' }
 UDBCSQLite3Platform >> printDate: aTimestamp isoFormatOn: stream [
 	"Print the date as yyyy-mm-dd"
 	| monthNumber dayOfMonth |


### PR DESCRIPTION
In pharo 8, using a date in the where part of a query using SQLite3 backend, doesn't work because it wraps the date in single and double-quotes.
`WHERE theDate = "'2021-11-12'"`
I don't know if this was caused by a change in the way pharo handles strings or if it was already broken.

The superclass implementation does work properly. So removing the method works.