### PR TITLE
Adds single cache for type resolvers (avoid duplication)

### DIFF
--- a/src/Glorp/CacheManager.class.st
+++ b/src/Glorp/CacheManager.class.st
@@ -15,7 +15,7 @@ Class {
 		'subCaches',
 		'session'
 	],
-	#category : 'Glorp-Core'
+	#category : #'Glorp-Core'
 }
 
 { #category : #'*Glorp' }
@@ -48,10 +48,17 @@ CacheManager >> cacheFor: anObject [
 		ifFalse: [self cacheForClass: nonMetaClass].
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #'private/caching' }
 CacheManager >> cacheForClass: aClass [
-	^subCaches at: aClass
-		ifAbsentPut: [self makeCacheFor: aClass]
+	| resolver cacheClass |
+
+	resolver := (self session descriptorFor: aClass) typeResolver.
+	cacheClass := resolver usesInheritance
+		ifTrue: [ resolver rootClass ]
+		ifFalse: [ aClass ].
+	^ subCaches
+		at: cacheClass
+		ifAbsentPut: [ self makeCacheFor: cacheClass ]
 ]
 
 { #category : #querying }

--- a/src/Glorp/FilteredTypeMapping.class.st
+++ b/src/Glorp/FilteredTypeMapping.class.st
@@ -16,7 +16,7 @@ Class {
 		'key',
 		'keyDictionary'
 	],
-	#category : 'Glorp-Mappings'
+	#category : #'Glorp-Mappings'
 }
 
 { #category : #'instance creation' }
@@ -28,12 +28,21 @@ FilteredTypeMapping class >> to: field keyedBy: key [
 { #category : #mapping }
 FilteredTypeMapping >> addTypeMappingCriteriaTo: collection in: base [
 	| singleRightValue r l |
-	singleRightValue := self keys size = 1.
-	r := ConstantExpression for: (singleRightValue
-											ifTrue: [self keys asArray first]
-											ifFalse: [self keys]).
+	key isNil
+		ifTrue: [ singleRightValue := self keys size = 1.
+			r := ConstantExpression
+				for:
+					(singleRightValue
+						ifTrue: [ self keys asArray first ]
+						ifFalse: [ self keys ]) ]
+		ifFalse: [ singleRightValue := true.
+			r := ConstantExpression for: key ].
 	l := FieldExpression forField: self field basedOn: base.
-	collection add: (singleRightValue ifTrue: [l equals: r] ifFalse: [l in: r])
+	collection
+		add:
+			(singleRightValue
+				ifTrue: [ l equals: r ]
+				ifFalse: [ l in: r ])
 ]
 
 { #category : #'initialize-release' }

--- a/src/Glorp/RelationExpression.class.st
+++ b/src/Glorp/RelationExpression.class.st
@@ -390,25 +390,35 @@ RelationExpression >> primaryKeyFromDictionary: aDictionary [
 	"Given a set of parameters, return a primary key suitable for retrieving our target. Do this only if the expression is for a primary key, and has no other conditions than the primary key one.  If the table's primary key is composite, return the array that will be needed with the found values in the right position and nils elsewhere.  (If unreferenced primaryKey fields are nillable, this could return a matching key.  A query with other values elsewhere will throw away the primary key, returning nil.  One without will "
 
 	| left right field primaryKeyFields |
-	relation = #AND ifTrue:
-		[left := leftChild primaryKeyFromDictionary: aDictionary.
-		left isNil ifTrue: [^nil].
-		right := rightChild primaryKeyFromDictionary: aDictionary.
-		right isNil ifTrue: [^nil].
-		^self assembleCompositePrimaryKeyFrom: left and: right].
-	relation = #= ifFalse: [^nil].
+	relation = #AND
+		ifTrue: [ left := leftChild primaryKeyFromDictionary: aDictionary.
+			right := rightChild primaryKeyFromDictionary: aDictionary.
+			rightChild valueIn: aDictionary.
+			"Assume this might be filtered type resolver."
+			^leftChild relation == #IN
+				ifTrue: [ right  ]
+				ifFalse: [ left isNil | right isNil
+						ifTrue: [ nil ]
+						ifFalse: [ self assembleCompositePrimaryKeyFrom: left and: right ] ] ].
+	relation = #=
+		ifFalse: [ ^ nil ].
 	field := leftChild fieldFromMeOrSubclasses.
-	field isNil ifTrue: [^nil].
-	field isGlorpExpression ifTrue: [^nil].
-	field isPrimaryKey ifFalse: [^nil].
+	field isNil
+		ifTrue: [ ^ nil ].
+	field isGlorpExpression
+		ifTrue: [ ^ nil ].
+	field isPrimaryKey
+		ifFalse: [ ^ nil ].
 	primaryKeyFields := field table primaryKeyFields.
-	^primaryKeyFields size > 1
-		ifFalse: [rightChild valueIn: aDictionary]
-		ifTrue:
-			[(Array new: primaryKeyFields size withAll: DatabaseRow emptySlot)	"ensure no accidental nil-match"
-				"field table may be alias with PK fields of original, so (field table primaryKeyFields indexOf: field) = 0"
-				at: ((1 to: primaryKeyFields size) detect: [:i | (primaryKeyFields at: i) position = field position]) put: (rightChild valueIn: aDictionary);
-				yourself]
+	^ primaryKeyFields size > 1
+		ifFalse: [ rightChild valueIn: aDictionary ]
+		ifTrue: [ (Array new: primaryKeyFields size withAll: DatabaseRow emptySlot)
+				at:
+					((1 to: primaryKeyFields size)
+						detect: [ :i | (primaryKeyFields at: i) position = field position ])
+					put: (rightChild valueIn: aDictionary);
+				yourself	"ensure no accidental nil-match"
+			"field table may be alias with PK fields of original, so (field table primaryKeyFields indexOf: field) = 0" ]
 ]
 
 { #category : #'printing SQL' }


### PR DESCRIPTION
When you use a FilteredTypeResolver, e.g. with `Animal` as the root class with `Dog` and `Cat` as different types, if you read by looking at `Dog` and then look by looking at `Animal` (e.g. `session read: Animal`), you'll end up with two different instances stored in two different caches (one for `Animal` and another one for `Dog`).

This change removes that duplication, and always uses the root descriptor class for the cache of all the inherited instances.

It's old code I'm merging in order to catch up with the main codebase, the discussion comes from here:
https://groups.google.com/g/glorp-group/c/eccmfOergeY/m/OEHmWD-cDgAJ

I've been using it in production since many years now, and all the Glorp test suite pass with this modification in.