### PR TITLE
Accelerate insertion of large number of elements

### DIFF
--- a/src/Glorp/ObjectTransaction.class.st
+++ b/src/Glorp/ObjectTransaction.class.st
@@ -150,7 +150,9 @@ ObjectTransaction >> registeredObjectsDo: aBlock [
 			newAdditions := OrderedCollection new.
 			undoMap
 				keysDo:
-					[:eachKey | (previousVersion includes: eachKey) ifFalse: [newAdditions add: eachKey]]]
+					[:eachKey | (previousVersion includes: eachKey) ifFalse: [newAdditions add: eachKey]].
+			newAdditions isEmpty ifFalse: [previousVersion := undoMap keys asSet]
+				]
 ]
 
 { #category : #registering }

--- a/src/Glorp/ObjectTransaction.class.st
+++ b/src/Glorp/ObjectTransaction.class.st
@@ -143,7 +143,7 @@ ObjectTransaction >> registeredObjectsDo: aBlock [
 
 	| newAdditions previousVersion |
 	newAdditions := undoMap keys.
-	previousVersion := newAdditions.
+	previousVersion := newAdditions asSet.
 	[newAdditions isEmpty]
 		whileFalse:
 			[newAdditions do: aBlock.

--- a/src/Glorp/ObjectTransaction.class.st
+++ b/src/Glorp/ObjectTransaction.class.st
@@ -139,7 +139,7 @@ in VA, which might have side-effects.  This feature's tests have been altered to
 
 { #category : #registering }
 ObjectTransaction >> registeredObjectsDo: aBlock [
-	"Iterate over all our objects. Note that this will include objects without descriptors. Be sure we're iterating over a copy of the keys, because this will add objects to the undoMap. Allow the block to return a collection which we will then add to the list of things to process, until there's nothing further"
+	"Iterate over all our objects. Note that this will include objects without descriptors. Be sure we're iterating over a copy of the keys, because `aBlock` may add objects to the undoMap. Allow the block to return a collection which we will then add to the list of things to process, until there's nothing further"
 
 	| newAdditions previousVersion |
 	newAdditions := undoMap keys.
@@ -151,7 +151,7 @@ ObjectTransaction >> registeredObjectsDo: aBlock [
 			undoMap
 				keysDo:
 					[:eachKey | (previousVersion includes: eachKey) ifFalse: [newAdditions add: eachKey]].
-			newAdditions ifNotEmpty: [previousVersion := undoMap keys asSet]
+			newAdditions ifNotEmpty: [previousVersion addAll: newAdditions ]
 				]
 ]
 

--- a/src/Glorp/ObjectTransaction.class.st
+++ b/src/Glorp/ObjectTransaction.class.st
@@ -150,8 +150,7 @@ ObjectTransaction >> registeredObjectsDo: aBlock [
 			newAdditions := OrderedCollection new.
 			undoMap
 				keysDo:
-					[:eachKey | (previousVersion includes: eachKey) ifFalse: [newAdditions add: eachKey]].
-			newAdditions isEmpty ifFalse: [previousVersion := undoMap keys]]
+					[:eachKey | (previousVersion includes: eachKey) ifFalse: [newAdditions add: eachKey]]]
 ]
 
 { #category : #registering }

--- a/src/Glorp/ObjectTransaction.class.st
+++ b/src/Glorp/ObjectTransaction.class.st
@@ -151,7 +151,7 @@ ObjectTransaction >> registeredObjectsDo: aBlock [
 			undoMap
 				keysDo:
 					[:eachKey | (previousVersion includes: eachKey) ifFalse: [newAdditions add: eachKey]].
-			newAdditions isEmpty ifFalse: [previousVersion := undoMap keys asSet]
+			newAdditions ifNotEmpty: [previousVersion := undoMap keys asSet]
 				]
 ]
 


### PR DESCRIPTION
ObjectTransaction>>registeredObjectsDo: iterates over a collection and checks if the element belongs to another collection. This verification uses Array>>includes: which traverses the array until an element is found. For a small number of elements this approach is OK. but when the number of elements increases, then the verification algorithm is O(n^2).

Converting the search array into a set makes the behavior almost linear again for large sizes and has no impact on smaller sized batches.

See time improvement after change:
<img width="385" alt="image" src="https://github.com/pharo-rdbms/glorp/assets/27969022/8bde7227-719a-42f4-b825-4a8fc307b0d4">


