### PR TITLE
Let's pin tonel format to 1.0

### DIFF
--- a/src/.properties
+++ b/src/.properties
@@ -1,3 +1,4 @@
 {
-	#format : #tonel
+	#format : #tonel,
+	#version: #'1.0'
 }


### PR DESCRIPTION
To avoid having a lot of noise in future commits, I propose pinning the tonel format to 1.0.