### PR TITLE
Add pharo 12 and new postgresql versions to the CI test matrix

### DIFF
--- a/.github/workflows/postgreSQL-integration-tests.yml
+++ b/.github/workflows/postgreSQL-integration-tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-8.0, Pharo64-9.0, Pharo64-10, Pharo64-11 ]
-        rdbms: [ PostgreSQLv10, PostgreSQLv11, PostgreSQLv12, PostgreSQLv13, PostgreSQLv14 ]
+        smalltalk: [ Pharo64-8.0, Pharo64-9.0, Pharo64-10, Pharo64-11, Pharo64-12 ]
+        rdbms: [ PostgreSQLv10, PostgreSQLv11, PostgreSQLv12, PostgreSQLv13, PostgreSQLv14, PostgreSQLv15, PostgreSQLv16 ]
     name: ${{ matrix.smalltalk }} + ${{ matrix.rdbms }}
     steps:
       - uses: actions/checkout@v2

--- a/src/.properties
+++ b/src/.properties
@@ -1,3 +1,4 @@
 {
-	#format : #tonel
+	#format : #tonel,
+	#version: #'1.0'
 }


### PR DESCRIPTION
Let's prepare to update glorp to Pharo 12 by preparing the CI environment. Tests will fail for Pharo 12.