### PR TITLE
Fix database accessor dependents

### DIFF
--- a/.github/workflows/postgreSQL-integration-tests.yml
+++ b/.github/workflows/postgreSQL-integration-tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-8.0, Pharo64-9.0, Pharo64-10, Pharo64-11 ]
-        rdbms: [ PostgreSQLv10, PostgreSQLv11, PostgreSQLv12, PostgreSQLv13, PostgreSQLv14 ]
+        smalltalk: [ Pharo64-8.0, Pharo64-9.0, Pharo64-10, Pharo64-11, Pharo64-12 ]
+        rdbms: [ PostgreSQLv10, PostgreSQLv11, PostgreSQLv12, PostgreSQLv13, PostgreSQLv14, PostgreSQLv15, PostgreSQLv16 ]
     name: ${{ matrix.smalltalk }} + ${{ matrix.rdbms }}
     steps:
       - uses: actions/checkout@v2

--- a/src/BaselineOfGlorp/BaselineOfGlorp.class.st
+++ b/src/BaselineOfGlorp/BaselineOfGlorp.class.st
@@ -25,7 +25,7 @@ BaselineOfGlorp >> baseline: spec [
 			spec group: 'Glorp-Tests' with: 'Tests'
 			].
 	spec
-		for: #(#'pharo10.x' #'pharo11.x')
+		for: #(#'pharo10.x' #'pharo11.x' #'pharo12.x')
 		do: [ spec
 				package: 'Glorp-Pharo10';
 				group: 'Core' with: 'Glorp-Pharo10'

--- a/src/Glorp/DatabaseAccessor.class.st
+++ b/src/Glorp/DatabaseAccessor.class.st
@@ -32,7 +32,6 @@ Class {
 		'reusePreparedStatements',
 		'deniedCommands',
 		'mutex',
-		'dependents',
 		'logOnly',
 		'logger'
 	],
@@ -986,18 +985,6 @@ DatabaseAccessor >> loginIfError: aBlock [
 DatabaseAccessor >> logout [
 
 	^ self subclassResponsibility
-]
-
-{ #category : #dependencies }
-DatabaseAccessor >> myDependents [
-
-	^ dependents
-]
-
-{ #category : #dependencies }
-DatabaseAccessor >> myDependents: aCollection [
-
-	dependents := aCollection
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Removes ad-hoc implementation of myDependents which breaks Glorp In pharo 12.

Also fixes baseline so that Glorp loads correctly in P12.

Fixes #155.
Fixes #125.